### PR TITLE
Elements are lost from arrays of arrays

### DIFF
--- a/examples/singlePerson.ged
+++ b/examples/singlePerson.ged
@@ -1,0 +1,11 @@
+﻿0 @I1@ INDI
+1 NAME John /Doe/
+1 OCCU Scholar
+2 SOUR School Book
+1 OCCU Soldier
+2 SOUR Army records
+2 SOUR Government records
+3 TEXT Page number: 2140
+3 REFN http://URL.com/95105046
+4 TYPE URL
+0 TRLR

--- a/src/ToJSON/processing/result.ts
+++ b/src/ToJSON/processing/result.ts
@@ -177,7 +177,17 @@ export function CreateMainObject(objects: ParsingObject[]): MainObject {
                 return;
             }
 
-            partPath.push(property);
+            partPath.push(property); 
+            
+            const parentPath = dropRight(partPath);
+            const parentObj = objectPath.get(result, parentPath);
+
+            if (parentPath.length > 0 && objectPath.has(result, parentPath) && isArray(parentObj)) {
+                partPath = parentPath;
+                partPath.push(`${parentObj.length - 1}`);
+                partPath.push(property);
+            }
+
             if (!objectPath.has(result, partPath)) {
                 objectPath.set(result, partPath, {});
                 return;


### PR DESCRIPTION
If a GEDCOM contains arrays of arrays of elements, then the lowest layer elements are lost from the JSON.

This can be demonstrated with:

```
0 @I1@ INDI
1 NAME John /Doe/
1 OCCU Scholar
2 SOUR School Book
1 OCCU Soldier
2 SOUR Army records
2 SOUR Government records
3 TEXT Page number: 2140
3 REFN http://URL.com/95105046
4 TYPE URL
0 TRLR
```

Expected:

```JSON
{
 "Individuals": [
  {
   "Id": "@I1@",
   "Fullname": "John /Doe/",
   "Occupation": [
    {
     "Value": "Scholar",
     "Source": {
      "Name": "School Book"
     }
    },
    {
     "Value": "Soldier",
     "Source": [
      {
       "Name": "Army records"
      },
      {
       "Name": "Government records",
       "Text": "Page number: 2140",
       "Reference": {
        "Value": "http://URL.com/95105046",
        "Type": "URL"
       }
      }
     ]
    }
   ]
  }
 ]
}
```

Actual:

```JSON
{
 "Individuals": [
  {
   "Id": "@I1@",
   "Fullname": "John /Doe/",
   "Occupation": [
    {
     "Value": "Scholar",
     "Source": {
      "Name": "School Book"
     }
    },
    {
     "Value": "Soldier",
     "Source": [
      {
       "Name": "Army records"
      },
      {
       "Name": "Government records"
      }
     ]
    }
   ]
  }
 ]
}
```

Notice the `TEXT` and `REFN` elements are lost.

The problem occurs in `result.ts` because only the lowest level of an array is considered when settings all sub-objects and building `partPath` to get the existing values.

The fix is to correctly set `partPath` to include which element in an array to try to get.