### PR TITLE
FEATURE: Add options to conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,15 @@ I am aware that there are already several parsers for the gedcom format. However
 
 Just run npx ts-node src/console.ts  with the wanted flags. Eg if you run "npm run demo:JSON" it will execute "ts-node src/console.ts --path 'examples/simpsons.get'" and will print out the Simpsons GEDCOM examplke file as JSON object in the console. With "npm run demoFile:JSON" it will do the same but prints the JSON object in a 'test.json' file.
 
-| Flag             | Description                                                  |
-| ---------------- | ------------------------------------------------------------ |
-| --onlyStats      | Only print the parsing statistcs to the console              |
-| --opt *xxx.yaml* | Set the path to the yaml [definition file](#create-your-own-defintion-file) |
-| --out *xxx.json* | File path to print into                                      |
-| --path *xxx.ged* | Set the path to the GEDCOM file                              |
-| --silent         | Don't print anything to the console                          |
-| --showProgress   | Print the progress during processing the file                |
+| Flag                 | Description                                                                 |
+| -------------------- | --------------------------------------------------------------------------- |
+| --onlyStats          | Only print the parsing statistics to the console                            |
+| --opt *xxx.yaml*     | Set the path to the yaml [definition file](#create-your-own-defintion-file) |
+| --out *xxx.json*     | File path to print into                                                     |
+| --path *xxx.ged*     | Set the path to the GEDCOM file                                             |
+| --silent             | Don't print anything to the console                                         |
+| --showProgress       | Print the progress during processing the file                               |
+| --saveWithStatistics | Save the processing statistics with the converted GEDCOM                    |
 
 ##### Via Node or JS
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,13 +32,15 @@ I am aware that there are already several parsers for the gedcom format. However
 
 Just run npx ts-node src/index.ts  with the wanted flags. Eg if you run "npm run demo:JSON" it will execute "ts-node src/index.ts --path 'examples/simpsons.get'" and will print out the Simpsons GEDCOM examplke file as JSON object in the console. With "npm run demoFile:JSON" it will do the same but prints the JSON object in a 'test.json' file.
 
-| Flag             | Description                                                  |
-| ---------------- | ------------------------------------------------------------ |
-| --onlyStats      | Only print the parsing statistcs to the console              |
-| --opt *xxx.yaml* | Set the path to the yaml [definition file](#create-your-own-defintion-file) |
-| --out *xxx.json* | File path to print into                                      |
-| --path *xxx.ged* | Set the path to the GEDCOM file                              |
-| --silent         | Don't print anything to the console                          |
+| Flag                 | Description                                                                 |
+| -------------------- | --------------------------------------------------------------------------- |
+| --onlyStats          | Only print the parsing statistics to the console                            |
+| --opt *xxx.yaml*     | Set the path to the yaml [definition file](#create-your-own-defintion-file) |
+| --out *xxx.json*     | File path to print into                                                     |
+| --path *xxx.ged*     | Set the path to the GEDCOM file                                             |
+| --silent             | Don't print anything to the console                                         |
+| --showProgress       | Print the progress during processing the file                               |
+| --saveWithStatistics | Save the processing statistics with the converted GEDCOM                    |
 
 ##### Via Node or JS
 

--- a/options/version551.yaml
+++ b/options/version551.yaml
@@ -1,3 +1,7 @@
+Config:
+- IgnoreMaxLineLength: true
+- ExcludeParsedLinesFromStats: true
+- ReplaceIdentifiersWithUUIDs: true
 Definition:
 - Tag: ABBR
   Property: Abbreviation

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "line-by-line": "^0.1.6",
         "lodash": "^4.17.21",
         "object-path": "^0.11.8",
+        "uuid": "^9.0.1",
         "yargs": "^16.2.0"
       },
       "devDependencies": {
@@ -28,6 +29,7 @@
         "@types/mocha": "^8.2.0",
         "@types/node": "^14.14.12",
         "@types/object-path": "^0.11.0",
+        "@types/uuid": "9.0.8",
         "@types/yargs": "^15.0.12",
         "chai": "^4.2.0",
         "mocha": "^8.2.1",
@@ -462,6 +464,12 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@types/object-path/-/object-path-0.11.0.tgz",
       "integrity": "sha512-/tuN8jDbOXcPk+VzEVZzzAgw1Byz7s/itb2YI10qkSyy6nykJH02DuhfrflxVdAdE7AZ91h5X6Cn0dmVdFw2TQ==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -1377,6 +1385,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
+      "bin": {
+        "uuid": "bin/uuid"
       }
     },
     "node_modules/istanbul-lib-report": {
@@ -2402,12 +2420,15 @@
       }
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true,
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/which": {
@@ -3031,6 +3052,12 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@types/object-path/-/object-path-0.11.0.tgz",
       "integrity": "sha512-/tuN8jDbOXcPk+VzEVZzzAgw1Byz7s/itb2YI10qkSyy6nykJH02DuhfrflxVdAdE7AZ91h5X6Cn0dmVdFw2TQ==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "dev": true
     },
     "@types/yargs": {
@@ -3747,6 +3774,14 @@
         "p-map": "^3.0.0",
         "rimraf": "^3.0.0",
         "uuid": "^3.3.3"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "istanbul-lib-report": {
@@ -4537,10 +4572,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tsc --build ./tsconfig.json",
     "clean": "tsc --build ./tsconfig.json --clean",
     "demo:JSON": "ts-node src/console.ts --path 'examples/simpsons.ged'",
-    "demoFile:JSON": "ts-node src/console.ts --path 'examples/simpsons.ged' --out 'test.json'",
+    "demoFile:JSON": "ts-node src/console.ts --path 'examples/simpsons.ged' --out 'test.json' --saveWithStatistics",
     "demoFileWithProgress:JSON": "ts-node src/console.ts --path 'examples/royal92.ged' --out 'test.json' --showProgress",
     "test": "nyc mocha",
     "test:watch": "mocha --watch --watch-files src, tests/**/*.ts",
@@ -42,6 +42,7 @@
     "@types/node": "^14.14.12",
     "@types/object-path": "^0.11.0",
     "@types/yargs": "^15.0.12",
+    "@types/uuid": "9.0.8",
     "chai": "^4.2.0",
     "mocha": "^8.2.1",
     "nyc": "^15.1.0",
@@ -60,6 +61,7 @@
     "line-by-line": "^0.1.6",
     "lodash": "^4.17.21",
     "object-path": "^0.11.8",
+    "uuid": "^9.0.1",
     "yargs": "^16.2.0"
   }
 }

--- a/src/ToJSON/console.ts
+++ b/src/ToJSON/console.ts
@@ -32,7 +32,11 @@ export function Convert(argv:any) {
     let start = new Date().getTime();
     parse.ParseFileAsync().then(result => {
         if (argv.out) {
-            parse.SaveAs(result.Object, argv.out as string);
+            if (argv.saveWithStatistics) {
+                parse.SaveAs(result, argv.out as string);
+            } else {
+                parse.SaveAs(result.Object, argv.out as string);
+            }
         }
         else {
 

--- a/src/ToJSON/models/ParsingResult.ts
+++ b/src/ToJSON/models/ParsingResult.ts
@@ -1,10 +1,14 @@
 import Statistics from "./Statistics";
 
 export default class ParsingResult {
-    constructor(obj: Object, stats?: Statistics) {
+    constructor(obj: Object, stats?: Statistics, excludeParsedLinesFromStats?: boolean) {
         this.Object = obj;
-        
-        /* istanbul ignore next */ 
+
+        if (stats && excludeParsedLinesFromStats) {
+            delete stats.ParsedLines;
+        }
+
+        /* istanbul ignore next */
         this.Statistics = stats ?? new Statistics();
     }
 

--- a/src/ToJSON/models/Statistics.ts
+++ b/src/ToJSON/models/Statistics.ts
@@ -10,12 +10,13 @@ export default class Statistics {
         this.IncorrectLines = [];
         this.NotParsedLines = [];
         this.NotParsedLinesWithoutGEDCOMTag = [];
+        this.ParsedLineCount = 0;
     }
 
     /**
      * @returns list of all correct parsed lines
      */
-    ParsedLines: StatisticLine[];
+    ParsedLines?: StatisticLine[];
     /**
      * @returns list of all incorrect parsed lines
      */
@@ -30,11 +31,13 @@ export default class Statistics {
      */
     NotParsedLinesWithoutGEDCOMTag: StatisticLine[];
 
+    ParsedLineCount: number;
+
     /**
      * @returns a count of all correctly parsed lines
      */
     get ParsedLinesCount(): number {
-        return this.ParsedLines.length;
+        return this.ParsedLineCount;
     }
 
     /**
@@ -62,7 +65,7 @@ export default class Statistics {
      * @returns a count of all processed lines
      */
     get LinesCount(): number {
-        return this.ParsedLines.length + this.IncorrectLines.length + this.NotParsedLines.length + this.NotParsedLinesWithoutGEDCOMTag.length;
+        return this.ParsedLineCount + this.IncorrectLines.length + this.NotParsedLines.length + this.NotParsedLinesWithoutGEDCOMTag.length;
     }
 
     /**

--- a/src/ToJSON/parsing/lineValidation.ts
+++ b/src/ToJSON/parsing/lineValidation.ts
@@ -7,7 +7,7 @@ import { IsNumber } from '../../common';
  * @param line - The line text
  * @returns true if the line is valid
 */
-export function IsValidLine(line: string) : Boolean {
+export function IsValidLine(line: string, ignoreMaxLineLength?: boolean) : Boolean {
     // empty string
     if (isEmpty(line))     
     {
@@ -15,7 +15,7 @@ export function IsValidLine(line: string) : Boolean {
     }
 
     // max length is 255
-    if (line.length > 255){
+    if (!ignoreMaxLineLength && line.length > 255){
         return false;
     }
 

--- a/src/ToJSON/parsing/parseLine.ts
+++ b/src/ToJSON/parsing/parseLine.ts
@@ -30,7 +30,7 @@ export function ParseLine(line: string, lineNumber: number, lastLevel: number) :
     let refId = GetReferenceId(tagOrRef);
 
     if (refId !== undefined) {
-        if (refId.length > 23) {
+        if (refId.length > 23 && !refId.match(/.{8}-.{4}-.{4}-.{4}-.{12}/)) {
             return undefined;
         }
 

--- a/src/ToJSON/processing/manipulateValues.ts
+++ b/src/ToJSON/processing/manipulateValues.ts
@@ -17,7 +17,9 @@ export function ManipulateValue(definition: TagDefinition, line: ParsedLine) {
     let convertTo = definition.PropertyType ?? definition.ConvertTo;
 
     if (value.match(/^(@.*@)/)) {
-
+        if (value.match(/@.{8}-.{4}-.{4}-.{4}-.{12}@/)) {
+            value = value.replace(/@/g, '');
+        }
         if (definition.ConvertTo instanceof ConvertToArray) {
             return ConvertStringToArray(definition.ConvertTo, value);
         }

--- a/tests/ToJSON/ManipulateValue.tests.ts
+++ b/tests/ToJSON/ManipulateValue.tests.ts
@@ -20,6 +20,14 @@ describe('Mainpulate Values', () => {
 
         expect(result).to.be.deep.equal([""]);
     });
+
+    it('Replaces GEDCOM references which are UUIDs as plain UUIDs', () => {
+        let result = ManipulateValue(
+            new TagDefinition({}),
+            new ParsedLine(0, 0, "TAG", "", "@00000000-0000-0000-0000-000000000000@"));
+
+        expect(result).to.be.deep.equal("00000000-0000-0000-0000-000000000000");
+    })
 });
 
 describe('AddStartWith', () => {

--- a/tests/ToJSON/Parsing.tests.ts
+++ b/tests/ToJSON/Parsing.tests.ts
@@ -29,6 +29,36 @@ describe('Parsing text', () => {
         });
     });
 
+    it('Replaces GEDCOM references with UUIDs', () => {
+
+        let testData = `
+            0 INDI @I1@
+            0 @M1@ OBJE
+            0 TRLR
+        `.trimStart().trimEnd();
+
+        let options = `
+            Config:
+              - IgnoreMaxLineLength: true
+              - ExcludeParsedLinesFromStats: true
+              - ReplaceIdentifiersWithUUIDs: true
+            Definition:
+              - Tag: INDI
+                CollectAs: Individuals
+                Property: Id
+                CollectAsArray: true
+              - Tag: OBJE
+                Property: Id
+                CollectAs: Objects
+        `
+        const obj: any = ParseText(testData, options).Object;
+        const individual = obj.Individuals[0];
+        const media = obj.Objects;
+        expect(individual.Id).to.match(/.{8}-.{4}-.{4}-.{4}-.{12}/);
+        expect(media.Id).to.match(/.{8}-.{4}-.{4}-.{4}-.{12}/);
+
+    });
+
     it('With Progress', () => {
         let testData = `
         0 @N00010@ NOTE

--- a/tests/ToJSON/ParsingResult.tests.ts
+++ b/tests/ToJSON/ParsingResult.tests.ts
@@ -1,0 +1,49 @@
+import { expect } from 'chai';
+import { ParseText } from '../../src/ToJSON/parsing/parsing';
+
+describe('Get result', () => {
+    it('Includes the result and statistics', () => {
+
+        let testData = `
+            0 @I1@ INDI
+            1 NAME John /Doe/
+            1 OCCU Scholar
+            0 TRLR
+        `.trimStart().trimEnd();
+
+        let options = `
+            Config:
+              - IgnoreMaxLineLength: true
+              - ExcludeParsedLinesFromStats: true
+              - ReplaceIdentifiersWithUUIDs: false
+            Definition:
+              - Tag: INDI
+                CollectAs: Individuals
+                CollectAsArray: true
+                Property: Id
+                Properties:
+                  - Tag: NAME
+                    Property: Fullname
+                  - Tag: OCCU
+                    Property: Occupation`;
+
+        const result = ParseText(testData, options);
+        expect(result).to.deep.equal({
+            Object: {
+                Individuals: [
+                    {
+                        Id: "@I1@",
+                        Fullname: "John /Doe/",
+                        Occupation: "Scholar"
+                    }
+                ]
+            },
+            Statistics: {
+                IncorrectLines: [],
+                NotParsedLines: [],
+                NotParsedLinesWithoutGEDCOMTag: [],
+                ParsedLineCount: 4
+            }
+        });
+    });
+});


### PR DESCRIPTION
I would be very grateful if you could consider adding the following extra features to the converter :-)

---

As part of converting the GEDCOM, this change adds four new options:

### `SaveWithStatistics`

When saving to a file via the console command, the output JSON also contains the conversion statistics alongside the main object.

This is set on the command line when converting. e.g.

```sh
ts-node src/console.ts --path 'examples/simpsons.ged' --out 'test.json' --saveWithStatistics
```

These next three are set in the YAML file (or supplied YAML config). e.g.

```yaml
Config:
- IgnoreMaxLineLength: true
- ExcludeParsedLinesFromStats: true
- ReplaceIdentifiersWithUUIDs: true

Definition:
- Tag: ABBR
  Property: Abbreviation
...
```

(They default to `false` if not supplied)

### `IgnoreMaxLineLength`

Lines in a GEDCOM file have no maximum length that would normally fail the validation.

Some GEDCOM files are not great at following the maximum length rule!

### `ExcludeParsedLinesFromStats`

The output statistics won't include the array of all the successfully converted lines. (Just the count of successes)
e.g.

```JSON
"Statistics": {
  "IncorrectLines": [],
  "NotParsedLines": [],
  "NotParsedLinesWithoutGEDCOMTag": [],
  "ParsedLineCount": 171
}
```

### `ReplaceIdentifiersWithUUIDs`

The converted JSON will have all reference keys replaced with UUIDs. e.g.

```
0 INDI @I1@
```

becomes

```JSON
{ "Id": "161E1518-2F23-412A-9ACE-B3571FA2E79C" }
```

🥇 