### PR TITLE
Ignore maximum line length

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,15 @@ I am aware that there are already several parsers for the gedcom format. However
 
 Just run npx ts-node src/console.ts with the wanted flags. Eg if you run "npm run demo:JSON" it will execute "ts-node src/console.ts --path 'examples/simpsons.get'" and will print out the Simpsons GEDCOM example file as JSON object in the console. With "npm run demoFile:JSON" it will do the same but prints the JSON object in a 'test.json' file.
 
-| Flag             | Description                                                                 |
-| ---------------- | --------------------------------------------------------------------------- |
-| --onlyStats      | Only print the parsing statistcs to the console                             |
-| --opt _xxx.yaml_ | Set the path to the yaml [definition file](#create-your-own-defintion-file) |
-| --out _xxx.json_ | File path to print into                                                     |
-| --path _xxx.ged_ | Set the path to the GEDCOM file                                             |
-| --silent         | Don't print anything to the console                                         |
-| --showProgress   | Print the progress during processing the file                               |
+| Flag                            | Description                                                                                  |
+| ------------------------------- | -------------------------------------------------------------------------------------------- |
+| --onlyStats                     | Only print the parsing statistcs to the console                                              |
+| --opt _xxx.yaml_                | Set the path to the yaml [definition file](#create-your-own-defintion-file)                  |
+| --conversion-options _xxx.yaml_ | Set the path to the yaml [conversion options file](#create-your-own-conversion-options-file) |
+| --out _xxx.json_                | File path to print into                                                                      |
+| --path _xxx.ged_                | Set the path to the GEDCOM file                                                              |
+| --silent                        | Don't print anything to the console                                                          |
+| --showProgress                  | Print the progress during processing the file                                                |
 
 ##### Via Node or JS
 
@@ -125,6 +126,19 @@ parse.SaveAs(result.Object, 'test.json');
 | NotParsedLinesWithoutGEDCOMTagCount | Count of all lines that has _NOT_ been parsed because their tag is not defined in the yaml definition file |
 | IncorrectLinesCount                 | Count of all incorrect lines (no tag, too long etc pp)                                                     |
 | IncorrectLines                      | Array of object from incorrect lines. Properties: _LineNumber_, _Line_ and _Text_                          |
+
+### Create your own conversion options file
+
+#### Structure
+
+The conversion options file starts with an **Options** property. Options available are:
+
+```yaml
+Options:
+  - IgnoreMaxLineLength: true
+```
+
+This will allow lines longer that 250 characters. Normally, these would fail a validation check.
 
 ### Create your own defintion file
 

--- a/options/conversion.yaml
+++ b/options/conversion.yaml
@@ -1,2 +1,2 @@
 Options:
-  - IgnoreMaxLineLength: true
+  - IgnoreMaxLineLength: false

--- a/options/conversion.yaml
+++ b/options/conversion.yaml
@@ -1,0 +1,2 @@
+Options:
+  - IgnoreMaxLineLength: true

--- a/src/ToJSON/console.ts
+++ b/src/ToJSON/console.ts
@@ -12,6 +12,10 @@ export function Convert(argv: any) {
     options.SetConfigFile(argv.opt as string);
   }
 
+  if (argv['conversion-options']) {
+    options.SetConversionOptionsFile(argv['conversion-options'] as string);
+  }
+
   if (argv.showProgress) {
     options.SetProgressFunction((linesCount: number, lineNumber: number) => {
       process.stdout.write(`\rProgress: parsing line ${lineNumber} from ${linesCount}`);

--- a/src/ToJSON/models/Parsing.ts
+++ b/src/ToJSON/models/Parsing.ts
@@ -18,7 +18,12 @@ export default class Parsing {
       return new ParsingResult({});
     }
 
-    return ParseText(this.options.GetText(), this.options.GetConfig(), this.options.GetProgressFunction());
+    return ParseText(
+      this.options.GetText(),
+      this.options.GetConfig(),
+      this.options.GetProgressFunction(),
+      this.options.GetConversionOptions()
+    );
   }
 
   ParseTextAsync(): Promise<ParsingResult> {
@@ -29,7 +34,9 @@ export default class Parsing {
     }
 
     return new Promise<ParsingResult>((resolve, reject) => {
-      resolve(ParseText(this.options.GetText(), this.options.GetConfig(), this.options.GetProgressFunction()));
+      resolve(
+        ParseText(this.options.GetText(), this.options.GetConfig(), this.options.GetProgressFunction(), this.options.GetConversionOptions())
+      );
     });
   }
 
@@ -39,7 +46,14 @@ export default class Parsing {
       return;
     }
 
-    ParseFile(filePath, this.options.GetConfig(), doneCallback, errorCallback, this.options.GetProgressFunction());
+    ParseFile(
+      filePath,
+      this.options.GetConfig(),
+      doneCallback,
+      errorCallback,
+      this.options.GetProgressFunction(),
+      this.options.GetConversionOptions()
+    );
   }
 
   ParseFileAsync(): Promise<ParsingResult> {

--- a/src/ToJSON/models/ParsingOptions.ts
+++ b/src/ToJSON/models/ParsingOptions.ts
@@ -2,6 +2,7 @@ export default class ParsingOptions {
   private text?: string;
   private filePath?: string;
   private config?: string;
+  private conversionOptions?: string;
   private progressFunction?: (linesCount: number, actualLine: number) => void;
 
   SetText(text: string) {
@@ -20,6 +21,14 @@ export default class ParsingOptions {
     this.config = config;
   }
 
+  SetConversionOptionsFile(path: string) {
+    this.conversionOptions = require('fs').readFileSync(path, 'utf8');
+  }
+
+  SetConversionOptions(config: string) {
+    this.conversionOptions = config;
+  }
+
   GetText() {
     return this.text;
   }
@@ -30,6 +39,10 @@ export default class ParsingOptions {
 
   GetConfig() {
     return this.config ?? require('fs').readFileSync('options/version551.yaml', 'utf8');
+  }
+
+  GetConversionOptions() {
+    return this.conversionOptions ?? require('fs').readFileSync('options/conversion.yaml', 'utf8');
   }
 
   SetProgressFunction(func: (linesCount: number, actualLine: number) => void) {

--- a/src/ToJSON/parsing/lineValidation.ts
+++ b/src/ToJSON/parsing/lineValidation.ts
@@ -7,14 +7,14 @@ import { IsNumber } from '../../common';
  * @param line - The line text
  * @returns true if the line is valid
  */
-export function IsValidLine(line: string): Boolean {
+export function IsValidLine(line: string, ignoreMaxLineLength?: boolean): Boolean {
   // empty string
   if (isEmpty(line)) {
     return false;
   }
 
   // max length is 255
-  if (line.length > 255) {
+  if (!ignoreMaxLineLength && line.length > 255) {
     return false;
   }
 

--- a/tests/ToJSON/Features.tests.ts
+++ b/tests/ToJSON/Features.tests.ts
@@ -185,4 +185,57 @@ describe('Features', () => {
       },
     });
   });
+
+  it('Ignores long lines when configured to do so', () => {
+    let testData = `
+    0 @1@ INDI
+    1 NOTE ${'abc '.repeat(100)}
+    0 TRLR`;
+
+    let options = `
+        Definition:
+          - Tag: INDI
+            CollectAs: Persons
+            Properties:
+              - Tag: NOTE
+                Property: Note
+        `;
+
+    let conversionOptions = `
+        Options:
+          - IgnoreMaxLineLength: true
+        `;
+
+    expect(ParseText(testData, options, undefined, conversionOptions).Object).to.deep.equal({
+      Persons: {
+        Note: 'abc '.repeat(100).trim(),
+      },
+    });
+  });
+
+  it('Ignores empty conversion options', () => {
+    let testData = `
+    0 @1@ INDI
+    1 NOTE abc
+    0 TRLR`;
+
+    let options = `
+        Definition:
+          - Tag: INDI
+            CollectAs: Persons
+            Properties:
+              - Tag: NOTE
+                Property: Note
+        `;
+
+    let conversionOptions = `
+        Options:
+        `;
+
+    expect(ParseText(testData, options, undefined, conversionOptions).Object).to.deep.equal({
+      Persons: {
+        Note: 'abc',
+      },
+    });
+  });
 });

--- a/tests/ToJSON/LineValidation.tests.ts
+++ b/tests/ToJSON/LineValidation.tests.ts
@@ -9,6 +9,9 @@ it('IsValidLine', () => {
   expect(IsValidLine('1 TAG' + ' '.repeat(250))).to.be.true;
   expect(IsValidLine('1 TAG' + ' '.repeat(251))).to.be.false;
 
+  // ignore max-line-length
+  expect(IsValidLine('1 TAG' + '_'.repeat(251), true)).to.be.true;
+
   // first char needs to be a number
   expect(IsValidLine('Q Tag')).to.be.false;
   expect(IsValidLine('A Tag')).to.be.false;

--- a/tests/ToJSON/ParsingOptions.tests.ts
+++ b/tests/ToJSON/ParsingOptions.tests.ts
@@ -31,10 +31,27 @@ describe('Parsing Options', () => {
     expect(options.GetConfig()).to.equal('ABC');
   });
 
+  it('Conversion Options File', () => {
+    const options = new ParsingOptions();
+
+    mock({
+      'ABC.yaml': 'ABC',
+    });
+
+    options.SetConversionOptionsFile('ABC.yaml');
+    expect(options.GetConversionOptions()).to.equal('ABC');
+  });
+
   it('Config', () => {
     const options = new ParsingOptions();
     options.SetConfig('ABC');
     expect(options.GetConfig()).to.equal('ABC');
+  });
+
+  it('Conversion Options', () => {
+    const options = new ParsingOptions();
+    options.SetConversionOptions('ABC');
+    expect(options.GetConversionOptions()).to.equal('ABC');
   });
 
   it('Progress', () => {

--- a/tests/ToJSON/ParsingWithOptions.tests.ts
+++ b/tests/ToJSON/ParsingWithOptions.tests.ts
@@ -76,6 +76,7 @@ describe('Parsing Model', () => {
   it('parse file', () => {
     const options = new ParsingOptions();
     const config = options.GetConfig();
+    const conversionOptions = options.GetConversionOptions();
     mock({
       'ABC.ged': `
                     0 @I1@ INDI
@@ -83,6 +84,7 @@ describe('Parsing Model', () => {
           `,
     });
     options.SetConfig(config);
+    options.SetConversionOptions(conversionOptions);
     options.SetFilePath('ABC.ged');
     const parsing = new Parsing(options);
     let result = {};
@@ -111,6 +113,7 @@ describe('Parsing Model', () => {
   it('parse file async', async () => {
     const options = new ParsingOptions();
     const config = options.GetConfig();
+    const conversionOptions = options.GetConversionOptions();
     mock({
       'ABC.ged': `
                     0 @I1@ INDI
@@ -118,6 +121,7 @@ describe('Parsing Model', () => {
           `,
     });
     options.SetConfig(config);
+    options.SetConversionOptions(conversionOptions);
     options.SetFilePath('ABC.ged');
     const parsing = new Parsing(options);
     const result = await parsing.ParseFileAsync();


### PR DESCRIPTION
Add an option to allow GEDCOM lines to be longer than 250 characters.

Normally, lines longer than this would fail a validation check, but depending on requirements, it might be OK to allow longer lines in incoming GEDCOMs.

The option is supplied by a new config setting `conversion-options` which points to a yaml file.

If the yaml file is not supplied, the included file is used and the setting defaults to false.

Example:

`=> options/conversion.yaml`

```yaml
Options:
  - IgnoreMaxLineLength: true
```

`=> examples/longAddress.ged`

```
0 @Abraham_Simpson@ INDI
1 NAME Abraham /Simpson/
1 ADDR Unit 1, The centre of the village, the middle of the town, right of the other place, left of the city square, somewhere in the midlands of the region, a bit to the north of the state, around the corner from the country, located centrally in the continent, somewhere in the world.
```

```sh
$: ts-node src/console.ts --path 'examples/longAddress.ged' --out 'test.json' --conversion-options 'options/conversion.yaml'
```

RESULT:

```json
{
 "Individuals": [
  {
   "Id": "@Abraham_Simpson@",
   "Fullname": "Abraham /Simpson/",
   "Address": "Unit 1, The centre of the village, the middle of the town, right of the other place, left of the city square, somewhere in the midlands of the region, a bit to the north of the state, around the corner from the country, located centrally in the continent, somewhere in the world."
  }
 ]
}
```