### PR TITLE
Replace Identifiers With UUIDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,15 @@ I am aware that there are already several parsers for the gedcom format. However
 
 Just run npx ts-node src/console.ts with the wanted flags. Eg if you run "npm run demo:JSON" it will execute "ts-node src/console.ts --path 'examples/simpsons.get'" and will print out the Simpsons GEDCOM example file as JSON object in the console. With "npm run demoFile:JSON" it will do the same but prints the JSON object in a 'test.json' file.
 
-| Flag             | Description                                                                 |
-| ---------------- | --------------------------------------------------------------------------- |
-| --onlyStats      | Only print the parsing statistcs to the console                             |
-| --opt _xxx.yaml_ | Set the path to the yaml [definition file](#create-your-own-defintion-file) |
-| --out _xxx.json_ | File path to print into                                                     |
-| --path _xxx.ged_ | Set the path to the GEDCOM file                                             |
-| --silent         | Don't print anything to the console                                         |
-| --showProgress   | Print the progress during processing the file                               |
+| Flag                            | Description                                                                                  |
+| ------------------------------- | -------------------------------------------------------------------------------------------- |
+| --onlyStats                     | Only print the parsing statistcs to the console                                              |
+| --opt _xxx.yaml_                | Set the path to the yaml [definition file](#create-your-own-defintion-file)                  |
+| --conversion-options _xxx.yaml_ | Set the path to the yaml [conversion options file](#create-your-own-conversion-options-file) |
+| --out _xxx.json_                | File path to print into                                                                      |
+| --path _xxx.ged_                | Set the path to the GEDCOM file                                                              |
+| --silent                        | Don't print anything to the console                                                          |
+| --showProgress                  | Print the progress during processing the file                                                |
 
 ##### Via Node or JS
 
@@ -125,6 +126,43 @@ parse.SaveAs(result.Object, 'test.json');
 | NotParsedLinesWithoutGEDCOMTagCount | Count of all lines that has _NOT_ been parsed because their tag is not defined in the yaml definition file |
 | IncorrectLinesCount                 | Count of all incorrect lines (no tag, too long etc pp)                                                     |
 | IncorrectLines                      | Array of object from incorrect lines. Properties: _LineNumber_, _Line_ and _Text_                          |
+
+### Create your own conversion options file
+
+#### Structure
+
+The conversion options file starts with an **Options** property. Options available are:
+
+```yaml
+Options:
+  - ReplaceIdentifiersWithUUIDs: false|true
+```
+
+If set to true, this will replace GEDCOM identifiers with standard UUIDs in the JSON.
+
+In a GEDCOM file, a unique identifier follows this pattern as standard:
+
+```
+@X1@
+```
+
+An @ symbol, followed by a letter, followed by a number, followed by an @ symbol.
+
+The identifiers are used to reference one part of a GEDCOM file with another part e.g.
+
+```
+0 INDI @I1@
+1 NAME Homer Simpson
+...
+0 FAM @F1@
+1 HUSB @I1@
+```
+
+Here, the ID for Homer is @I1@ which is used later in the family section in the Husband tag.
+
+But these identifiers are only unique within an individual GEDCOM file; another GEDCOM file may re-use these identifiers for other objects. Also, the format of these identifiers is specific to GEDCOM files.
+
+When converting to a JSON file, it's often useful to have identifiers that follow standard conventions and are unique across different instances of files. Hence the option to replace GEDCOM identifiers with standard UUIDs.
 
 ### Create your own defintion file
 

--- a/options/conversion.yaml
+++ b/options/conversion.yaml
@@ -1,0 +1,2 @@
+Options:
+  - ReplaceIdentifiersWithUUIDs: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "line-by-line": "^0.1.6",
         "lodash": "^4.17.21",
         "object-path": "^0.11.8",
+        "uuid": "^9.0.1",
         "yargs": "^16.2.0"
       },
       "devDependencies": {
@@ -30,6 +31,7 @@
         "@types/mock-fs": "^4.13.4",
         "@types/node": "^14.14.12",
         "@types/object-path": "^0.11.0",
+        "@types/uuid": "^9.0.8",
         "@types/yargs": "^15.0.12",
         "chai": "^4.2.0",
         "chai-as-promised": "^7.1.1",
@@ -682,6 +684,12 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@types/object-path/-/object-path-0.11.0.tgz",
       "integrity": "sha512-/tuN8jDbOXcPk+VzEVZzzAgw1Byz7s/itb2YI10qkSyy6nykJH02DuhfrflxVdAdE7AZ91h5X6Cn0dmVdFw2TQ==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -1624,6 +1632,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
+      "bin": {
+        "uuid": "bin/uuid"
       }
     },
     "node_modules/istanbul-lib-report": {
@@ -2771,12 +2789,15 @@
       }
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true,
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -3571,6 +3592,12 @@
       "integrity": "sha512-/tuN8jDbOXcPk+VzEVZzzAgw1Byz7s/itb2YI10qkSyy6nykJH02DuhfrflxVdAdE7AZ91h5X6Cn0dmVdFw2TQ==",
       "dev": true
     },
+    "@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "dev": true
+    },
     "@types/yargs": {
       "version": "15.0.12",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.12.tgz",
@@ -4294,6 +4321,14 @@
         "p-map": "^3.0.0",
         "rimraf": "^3.0.0",
         "uuid": "^3.3.3"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "istanbul-lib-report": {
@@ -5158,10 +5193,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@types/mock-fs": "^4.13.4",
     "@types/node": "^14.14.12",
     "@types/object-path": "^0.11.0",
+    "@types/uuid": "^9.0.8",
     "@types/yargs": "^15.0.12",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
@@ -65,6 +66,7 @@
     "line-by-line": "^0.1.6",
     "lodash": "^4.17.21",
     "object-path": "^0.11.8",
+    "uuid": "^9.0.1",
     "yargs": "^16.2.0"
   }
 }

--- a/src/ToJSON/console.ts
+++ b/src/ToJSON/console.ts
@@ -12,6 +12,10 @@ export function Convert(argv: any) {
     options.SetConfigFile(argv.opt as string);
   }
 
+  if (argv['conversion-options']) {
+    options.SetConversionOptionsFile(argv['conversion-options'] as string);
+  }
+
   if (argv.showProgress) {
     options.SetProgressFunction((linesCount: number, lineNumber: number) => {
       process.stdout.write(`\rProgress: parsing line ${lineNumber} from ${linesCount}`);

--- a/src/ToJSON/models/Parsing.ts
+++ b/src/ToJSON/models/Parsing.ts
@@ -18,7 +18,12 @@ export default class Parsing {
       return new ParsingResult({});
     }
 
-    return ParseText(this.options.GetText(), this.options.GetConfig(), this.options.GetProgressFunction());
+    return ParseText(
+      this.options.GetText(),
+      this.options.GetConfig(),
+      this.options.GetProgressFunction(),
+      this.options.GetConversionOptions()
+    );
   }
 
   ParseTextAsync(): Promise<ParsingResult> {
@@ -29,7 +34,9 @@ export default class Parsing {
     }
 
     return new Promise<ParsingResult>((resolve, reject) => {
-      resolve(ParseText(this.options.GetText(), this.options.GetConfig(), this.options.GetProgressFunction()));
+      resolve(
+        ParseText(this.options.GetText(), this.options.GetConfig(), this.options.GetProgressFunction(), this.options.GetConversionOptions())
+      );
     });
   }
 
@@ -39,7 +46,14 @@ export default class Parsing {
       return;
     }
 
-    ParseFile(filePath, this.options.GetConfig(), doneCallback, errorCallback, this.options.GetProgressFunction());
+    ParseFile(
+      filePath,
+      this.options.GetConfig(),
+      doneCallback,
+      errorCallback,
+      this.options.GetProgressFunction(),
+      this.options.GetConversionOptions()
+    );
   }
 
   ParseFileAsync(): Promise<ParsingResult> {

--- a/src/ToJSON/models/ParsingOptions.ts
+++ b/src/ToJSON/models/ParsingOptions.ts
@@ -2,6 +2,7 @@ export default class ParsingOptions {
   private text?: string;
   private filePath?: string;
   private config?: string;
+  private conversionOptions?: string;
   private progressFunction?: (linesCount: number, actualLine: number) => void;
 
   SetText(text: string) {
@@ -20,6 +21,14 @@ export default class ParsingOptions {
     this.config = config;
   }
 
+  SetConversionOptionsFile(path: string) {
+    this.conversionOptions = require('fs').readFileSync(path, 'utf8');
+  }
+
+  SetConversionOptions(config: string) {
+    this.conversionOptions = config;
+  }
+
   GetText() {
     return this.text;
   }
@@ -30,6 +39,10 @@ export default class ParsingOptions {
 
   GetConfig() {
     return this.config ?? require('fs').readFileSync('options/version551.yaml', 'utf8');
+  }
+
+  GetConversionOptions() {
+    return this.conversionOptions ?? require('fs').readFileSync('options/conversion.yaml', 'utf8');
   }
 
   SetProgressFunction(func: (linesCount: number, actualLine: number) => void) {

--- a/src/ToJSON/parsing/parseLine.ts
+++ b/src/ToJSON/parsing/parseLine.ts
@@ -30,7 +30,7 @@ export function ParseLine(line: string, lineNumber: number, lastLevel: number): 
   let refId = GetReferenceId(tagOrRef);
 
   if (refId !== undefined) {
-    if (refId.length > 23) {
+    if (refId.length > 23 && !refId.match(/.{8}-.{4}-.{4}-.{4}-.{12}/)) {
       return undefined;
     }
 

--- a/src/ToJSON/processing/manipulateValues.ts
+++ b/src/ToJSON/processing/manipulateValues.ts
@@ -17,6 +17,9 @@ export function ManipulateValue(definition: TagDefinition, line: ParsedLine) {
   let convertTo = definition.PropertyType ?? definition.ConvertTo;
 
   if (value.match(/^(@.*@)/)) {
+    if (value.match(/@.{8}-.{4}-.{4}-.{4}-.{12}@/)) {
+      value = value.replace(/@/g, '');
+    }
     if (definition.ConvertTo instanceof ConvertToArray) {
       return ConvertStringToArray(definition.ConvertTo, value);
     }

--- a/tests/ToJSON/Features.tests.ts
+++ b/tests/ToJSON/Features.tests.ts
@@ -185,4 +185,30 @@ describe('Features', () => {
       },
     });
   });
+
+  it('Ignores empty conversion options', () => {
+    let testData = `
+    0 @1@ INDI
+    1 NOTE abc
+    0 TRLR`;
+
+    let options = `
+        Definition:
+          - Tag: INDI
+            CollectAs: Persons
+            Properties:
+              - Tag: NOTE
+                Property: Note
+        `;
+
+    let conversionOptions = `
+        Options:
+        `;
+
+    expect(ParseText(testData, options, undefined, conversionOptions).Object).to.deep.equal({
+      Persons: {
+        Note: 'abc',
+      },
+    });
+  });
 });

--- a/tests/ToJSON/ManipulateValue.tests.ts
+++ b/tests/ToJSON/ManipulateValue.tests.ts
@@ -26,6 +26,12 @@ describe('Mainpulate Values', () => {
 
     expect(result).to.be.deep.equal(['']);
   });
+
+  it('Replaces GEDCOM references which are UUIDs as plain UUIDs', () => {
+    let result = ManipulateValue(new TagDefinition({}), new ParsedLine(0, 0, 'TAG', '', '@00000000-0000-0000-0000-000000000000@'));
+
+    expect(result).to.be.deep.equal('00000000-0000-0000-0000-000000000000');
+  });
 });
 
 describe('AddStartWith', () => {

--- a/tests/ToJSON/ParsingOptions.tests.ts
+++ b/tests/ToJSON/ParsingOptions.tests.ts
@@ -31,10 +31,27 @@ describe('Parsing Options', () => {
     expect(options.GetConfig()).to.equal('ABC');
   });
 
+  it('Conversion Options File', () => {
+    const options = new ParsingOptions();
+
+    mock({
+      'ABC.yaml': 'ABC',
+    });
+
+    options.SetConversionOptionsFile('ABC.yaml');
+    expect(options.GetConversionOptions()).to.equal('ABC');
+  });
+
   it('Config', () => {
     const options = new ParsingOptions();
     options.SetConfig('ABC');
     expect(options.GetConfig()).to.equal('ABC');
+  });
+
+  it('Conversion Options', () => {
+    const options = new ParsingOptions();
+    options.SetConversionOptions('ABC');
+    expect(options.GetConversionOptions()).to.equal('ABC');
   });
 
   it('Progress', () => {

--- a/tests/ToJSON/ParsingWithOptions.tests.ts
+++ b/tests/ToJSON/ParsingWithOptions.tests.ts
@@ -76,6 +76,7 @@ describe('Parsing Model', () => {
   it('parse file', () => {
     const options = new ParsingOptions();
     const config = options.GetConfig();
+    const conversionOptions = options.GetConversionOptions();
     mock({
       'ABC.ged': `
                     0 @I1@ INDI
@@ -83,6 +84,7 @@ describe('Parsing Model', () => {
           `,
     });
     options.SetConfig(config);
+    options.SetConversionOptions(conversionOptions);
     options.SetFilePath('ABC.ged');
     const parsing = new Parsing(options);
     let result = {};
@@ -111,6 +113,7 @@ describe('Parsing Model', () => {
   it('parse file async', async () => {
     const options = new ParsingOptions();
     const config = options.GetConfig();
+    const conversionOptions = options.GetConversionOptions();
     mock({
       'ABC.ged': `
                     0 @I1@ INDI
@@ -118,6 +121,7 @@ describe('Parsing Model', () => {
           `,
     });
     options.SetConfig(config);
+    options.SetConversionOptions(conversionOptions);
     options.SetFilePath('ABC.ged');
     const parsing = new Parsing(options);
     const result = await parsing.ParseFileAsync();


### PR DESCRIPTION
This change will add an option to replace GEDCOM identifiers with standard UUIDs in the JSON.

In a GEDCOM file, a unique identifier follows this pattern as standard:

```
@X1@
```

An @ symbol, followed by a letter, followed by a number, followed by an @ symbol. (It's also OK to have any alpha-numeric pattern within two @ symbols, but a letter and a number is very common.)

The identifiers are used to reference one part of a GEDCOM file with another part e.g.

```
0 @I1@ INDI
1 NAME Homer /Simpson/
...
0 @F1@ FAM
1 HUSB @I1@
```

Here, the ID for Homer is `@I1@` which is used later in the family section in the Husband tag.

But these identifiers are only unique within an individual GEDCOM file; another GEDCOM file may re-use these identifiers for other objects. Also, the format of these identifiers is specific to GEDCOM files.

When converting to a JSON file, it's often useful to have identifiers that follow standard conventions and are unique across different instances of files. Hence the option to replace GEDCOM identifiers with standard UUIDs.

Example:

`conversion.yaml`

```yaml
Options:
  - ReplaceIdentifiersWithUUIDs: true
```

`test.ged`

```
0 @I1@ INDI
1 NAME Homer /Simpson/
1 OBJE @M1@
0 @M1@ OBJE
1 FILE http://some.url
0 TRLR
```

RESULT:

```JSON
{
 "Individuals": [
  {
   "Id": "E1E5F37E-45A4-4D73-9513-B8418D0515ED",
   "Fullname": "Homer /Simpson/",
   "Object": {
    "Id": "764F595F-C062-4DFC-95E6-266C572CA1C0"
   }
  }
 ],
 "Object": {
  "Id": "764F595F-C062-4DFC-95E6-266C572CA1C0",
  "File": "http://some.url"
 }
}
```